### PR TITLE
Fix "format not a string" compilation failure

### DIFF
--- a/asm/x86dis.cc
+++ b/asm/x86dis.cc
@@ -1218,15 +1218,15 @@ void x86dis::str_op(char *opstr, int *opstrlen, x86dis_insn *insn, x86_insn_op *
 		default: {assert(0);}
 		}
 		if (!insn->rexprefix) {
-			sprintf(opstr, x86_regs[j][op->reg]);
+			sprintf(opstr, "%s", x86_regs[j][op->reg]);
 		} else {
-			sprintf(opstr, x86_64regs[j][op->reg]);
+			sprintf(opstr, "%s", x86_64regs[j][op->reg]);
 		}
 		break;
 	}
 	case X86_OPTYPE_SEG:
 		if (x86_segs[op->seg]) {
-			sprintf(opstr, x86_segs[op->seg]);
+			sprintf(opstr, "%s", x86_segs[op->seg]);
 		}
 		break;
 	case X86_OPTYPE_CRX:

--- a/htpal.cc
+++ b/htpal.cc
@@ -307,7 +307,7 @@ void palette_entry::strvalue(char *buf32bytes)
 		text = "normal";
 	}
 	p = tag_make_color(p, 32, VCP(fg, bg));
-	p += sprintf(p, text);
+	p += sprintf(p, "%s", text);
 	p = tag_make_default_color(p, 32);
 	*p = 0;
 }


### PR DESCRIPTION
Compilation with the flag -Werror=format-security fails with
the message:

error: format not a string literal and no format arguments

This patch solves the issue.

This problem was found during the packaging ht_2.1.0 for Debian distribution.