### PR TITLE
automake AR detection rutine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,8 +104,7 @@ AC_PROG_CPP
 AC_PROG_CXX
 AC_PROG_YACC
 AM_PROG_LEX
-AC_PATH_PROG(AR, ar)
-AC_PATH_PROG(AR, gar)
+AM_PROG_AR
 
 if test "x$AR" = "x"; then
 	   AC_MSG_ERROR([*** 'ar' and 'gar' missing, please install one of them or fix your \$PATH ***])


### PR DESCRIPTION
Currently `ht` fails to build on system which uses target-specific prefixed binutils.
```sh
./configure \
  --build=x86_64-pc-linux-gnu \
  --host=x86_64-pc-linux-gnu \
  ...
...
checking for ar... no
checking for gar... no
configure: error: *** 'ar' and 'gar' missing, please install one of them or fix your $PATH ***
```

On the other hand automake provide `AM_PROG_AR` that threats this situation correctly.