### PR TITLE
fix ambiguous abs() call

### DIFF
--- a/htapp.cc
+++ b/htapp.cc
@@ -3023,7 +3023,7 @@ static uint isqr(uint u)
 {
 	int a = 2;
 	int b = u/a;
-	while (abs(a - b) > 1) {
+	while (abs((int)a - (int)b) > 1) {
 		a = (a+b)/2;
 		b = u/a;
         }


### PR DESCRIPTION
Latest clang/libc++ (e.g., from Xcode 9) rightly reject this

If big values of `a` and `b` are expected (that fit in `uint` but not in `int`), the logic needs to be changed anyway.