### PR TITLE
ht: fix build failure on -funsigned-char platforms

### DIFF
--- a/httag.h
+++ b/httag.h
@@ -69,7 +69,7 @@ struct ht_tag_flags {
 } PACKED;
 
 struct ht_tag_flags_s {
-	char bitidx;
+	signed char bitidx;
 	const char *desc;
 } PACKED;
 


### PR DESCRIPTION
powerpc (and arm) have 'char' == 'unsigned char' by default.
This causes build failures on c++11:

```
$ ./configure CFLAGS=-funsigned-char CXXFLAGS=-funsigned-char
$ make

g++ -DHAVE_CONFIG_H -I.   -I./analyser -I./asm -I./info -I./io/posix -I./io -I./output -I./eval -I.   -DNOMACROS -pipe -O3 -fomit-frame-pointer -Wall -fsigned-char -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64  -std=c++14 -Woverloaded-virtual -Wnon-virtual-dtor -funsigned-char -MT htcoffhd.o -MD -MP -MF .deps/htcoffhd.Tpo -c -o htcoffhd.o htcoffhd.cc
htcoffhd.cc:93:1: error: narrowing conversion of '-1' from 'int' to 'char' inside { } [-Wnarrowing]
 };
 ^
htcoffhd.cc:131:1: error: narrowing conversion of '-1' from 'int' to 'char' inside { } [-Wnarrowing]
 };
```

Use 'signed char' explicitly to maintain existing behavior.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>