### PR TITLE
Remove PACKED from ht_tag_flags_s struct.

### DIFF
--- a/httag.h
+++ b/httag.h
@@ -71,7 +71,7 @@ struct ht_tag_flags {
 struct ht_tag_flags_s {
 	char bitidx;
 	const char *desc;
-} PACKED;
+};
 
 /* GROUP-TAG */
 #define HT_TAG_GROUP				0x03


### PR DESCRIPTION
Some architectures like AppleSilicon do not allow
unaligned pointers, this fixes compilation on them. I could also not find a reason why this struct would need to be packed, and the resulting code seems to work fine without.