### PR TITLE
Fix eval internal dependencies

### DIFF
--- a/eval/Makefile.am
+++ b/eval/Makefile.am
@@ -10,6 +10,8 @@ AUTOMAKE_OPTIONS=foreign
 noinst_LIBRARIES = libhteval.a
 libhteval_a_SOURCES = evalparse.y evalparse.h eval.cc eval.h lex.l lex.h evalx.c evalx.h evaltype.h
 
+BUILT_SOURCES = evalparse.h evalparse.c lex.c
+
 #bin_PROGRAMS = testeval
 #testeval_SOURCES = testeval.c
 #testeval_LDADD = libhteval.a


### PR DESCRIPTION
flex and bison may regenerate the files evalparse.h evalparse.c and lex.c this may cause compilation errors if these are used before they are regenerated.

Mark these using BUILT_SOURCES so that automake correctly generates the dependency to ensure parallel compilation works as intended.